### PR TITLE
Updated LED and UART test

### DIFF
--- a/adafruit_boardtest/boardtest_uart.py
+++ b/adafruit_boardtest/boardtest_uart.py
@@ -92,7 +92,7 @@ def run_test(pins, tx_pin=TX_PIN_NAME, rx_pin=RX_PIN_NAME, baud_rate=BAUD_RATE):
             test_str += chr(random.randint(ASCII_MIN, ASCII_MAX))
 
         # Transmit test string
-        uart.write(test_str)
+        uart.write(bytearray(test_str))
         print("Transmitting:\t" + test_str)
 
         # Wait for received string


### PR DESCRIPTION
LED test did not allow for an onboard LED to share several labels. Fixed that. Updated UART test to transmit bytearray instead of string (which is no longer allowed).