### PR TITLE
Add typing, small documentation and implementation corrections

### DIFF
--- a/adafruit_boardtest/boardtest_gpio.py
+++ b/adafruit_boardtest/boardtest_gpio.py
@@ -29,6 +29,11 @@ import board
 import digitalio
 import supervisor
 
+try:
+    from typing import Any, Sequence, Tuple, List
+except ImportError:
+    pass
+
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BoardTest.git"
 
@@ -43,7 +48,7 @@ FAIL = "FAIL"
 NA = "N/A"
 
 # Determine if given value is a number
-def _is_number(val):
+def _is_number(val: Any) -> bool:
     try:
         float(val)
         return True
@@ -52,13 +57,13 @@ def _is_number(val):
 
 
 # Release pins
-def _deinit_pins(gpios):
+def _deinit_pins(gpios: Sequence[digitalio.DigitalInOut]) -> None:
     for g in gpios:
         g.deinit()
 
 
 # Toggle IO pins while waiting for answer
-def _toggle_wait(gpios):
+def _toggle_wait(gpios: Sequence[digitalio.DigitalInOut]) -> bool:
 
     timestamp = time.monotonic()
     led_state = False
@@ -79,7 +84,7 @@ def _toggle_wait(gpios):
             return bool(answer == "y")
 
 
-def run_test(pins):
+def run_test(pins: Sequence[str]) -> Tuple[str, List[str]]:
 
     """
     Toggles all available GPIO on and off repeatedly.

--- a/adafruit_boardtest/boardtest_i2c.py
+++ b/adafruit_boardtest/boardtest_i2c.py
@@ -56,7 +56,9 @@ FAIL = "FAIL"
 NA = "N/A"
 
 # Open comms to I2C EEPROM by trying a write to memory address
-def _eeprom_i2c_wait(i2c: busio.I2C, i2c_addr: int, mem_addr: int, timeout: float = 1.0) -> bool:
+def _eeprom_i2c_wait(
+    i2c: busio.I2C, i2c_addr: int, mem_addr: int, timeout: float = 1.0
+) -> bool:
 
     # Try to access the I2C EEPROM (it becomes unresonsive during a write)
     timestamp = time.monotonic()
@@ -71,7 +73,9 @@ def _eeprom_i2c_wait(i2c: busio.I2C, i2c_addr: int, mem_addr: int, timeout: floa
 
 
 # Write to address. Returns status (True for successful write, False otherwise)
-def _eeprom_i2c_write_byte(i2c: busio.I2C, i2c_addr: int, mem_addr: int, mem_data: int) -> bool:
+def _eeprom_i2c_write_byte(
+    i2c: busio.I2C, i2c_addr: int, mem_addr: int, mem_data: int
+) -> bool:
 
     # Make sure address is only one byte:
     if mem_addr > 255:
@@ -91,7 +95,9 @@ def _eeprom_i2c_write_byte(i2c: busio.I2C, i2c_addr: int, mem_addr: int, mem_dat
 
 
 # Read from address. Returns tuple [status, result]
-def _eeprom_i2c_read_byte(i2c: busio.I2C, i2c_addr: int, mem_addr: int, timeout: float = 1.0) -> Tuple[bool, bytearray]:
+def _eeprom_i2c_read_byte(
+    i2c: busio.I2C, i2c_addr: int, mem_addr: int, timeout: float = 1.0
+) -> Tuple[bool, bytearray]:
 
     # Make sure address is only one byte:
     if mem_addr > 255:
@@ -108,7 +114,9 @@ def _eeprom_i2c_read_byte(i2c: busio.I2C, i2c_addr: int, mem_addr: int, timeout:
     return True, buf
 
 
-def run_test(pins: Sequence[str], sda_pin: str = SDA_PIN_NAME, scl_pin: str = SCL_PIN_NAME) -> Tuple[str, List[str]]:
+def run_test(
+    pins: Sequence[str], sda_pin: str = SDA_PIN_NAME, scl_pin: str = SCL_PIN_NAME
+) -> Tuple[str, List[str]]:
 
     """
     Performs random writes and reads to I2C EEPROM.

--- a/adafruit_boardtest/boardtest_i2c.py
+++ b/adafruit_boardtest/boardtest_i2c.py
@@ -33,6 +33,11 @@ import time
 import board
 import busio
 
+try:
+    from typing import Tuple, Sequence, List
+except ImportError:
+    pass
+
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BoardTest.git"
 
@@ -51,7 +56,7 @@ FAIL = "FAIL"
 NA = "N/A"
 
 # Open comms to I2C EEPROM by trying a write to memory address
-def _eeprom_i2c_wait(i2c, i2c_addr, mem_addr, timeout=1.0):
+def _eeprom_i2c_wait(i2c: busio.I2C, i2c_addr: int, mem_addr: int, timeout: float = 1.0) -> bool:
 
     # Try to access the I2C EEPROM (it becomes unresonsive during a write)
     timestamp = time.monotonic()
@@ -66,7 +71,7 @@ def _eeprom_i2c_wait(i2c, i2c_addr, mem_addr, timeout=1.0):
 
 
 # Write to address. Returns status (True for successful write, False otherwise)
-def _eeprom_i2c_write_byte(i2c, i2c_addr, mem_addr, mem_data):
+def _eeprom_i2c_write_byte(i2c: busio.I2C, i2c_addr: int, mem_addr: int, mem_data: int) -> bool:
 
     # Make sure address is only one byte:
     if mem_addr > 255:
@@ -86,7 +91,7 @@ def _eeprom_i2c_write_byte(i2c, i2c_addr, mem_addr, mem_data):
 
 
 # Read from address. Returns tuple [status, result]
-def _eeprom_i2c_read_byte(i2c, i2c_addr, mem_addr, timeout=1.0):
+def _eeprom_i2c_read_byte(i2c: busio.I2C, i2c_addr: int, mem_addr: int, timeout: float = 1.0) -> Tuple[bool, bytearray]:
 
     # Make sure address is only one byte:
     if mem_addr > 255:
@@ -103,7 +108,7 @@ def _eeprom_i2c_read_byte(i2c, i2c_addr, mem_addr, timeout=1.0):
     return True, buf
 
 
-def run_test(pins, sda_pin=SDA_PIN_NAME, scl_pin=SCL_PIN_NAME):
+def run_test(pins: Sequence[str], sda_pin: str = SDA_PIN_NAME, scl_pin: str = SCL_PIN_NAME) -> Tuple[str, List[str]]:
 
     """
     Performs random writes and reads to I2C EEPROM.

--- a/adafruit_boardtest/boardtest_led.py
+++ b/adafruit_boardtest/boardtest_led.py
@@ -28,6 +28,11 @@ import board
 import digitalio
 import supervisor
 
+try:
+    from typing import Sequence, Tuple, List
+except ImportError:
+    pass
+
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BoardTest.git"
 
@@ -42,7 +47,7 @@ FAIL = "FAIL"
 NA = "N/A"
 
 # Toggle IO pins while waiting for answer
-def _toggle_wait(led_pins):
+def _toggle_wait(led_pins: Sequence[str]) -> bool:
     timestamp = time.monotonic()
     led_state = False
     print("Are the pins listed above toggling? [y/n]")
@@ -77,7 +82,7 @@ def _toggle_wait(led_pins):
                     return False
 
 
-def run_test(pins):
+def run_test(pins: Sequence[str]) -> Tuple[str, List[str]]:
 
     """
     Toggles the onboard LED(s) on and off.

--- a/adafruit_boardtest/boardtest_sd.py
+++ b/adafruit_boardtest/boardtest_sd.py
@@ -68,7 +68,7 @@ def run_test(
     miso_pin: str = MISO_PIN_NAME,
     sck_pin: str = SCK_PIN_NAME,
     cs_pin: str = CS_PIN_NAME,
-    filename: str = FILENAME
+    filename: str = FILENAME,
 ) -> Tuple[str, List[str]]:
 
     """

--- a/adafruit_boardtest/boardtest_sd.py
+++ b/adafruit_boardtest/boardtest_sd.py
@@ -62,7 +62,7 @@ FAIL = "FAIL"
 NA = "N/A"
 
 
-def run_test(
+def run_test(  # pylint: disable=too-many-arguments,too-many-locals
     pins: Sequence[str],
     mosi_pin: str = MOSI_PIN_NAME,
     miso_pin: str = MISO_PIN_NAME,

--- a/adafruit_boardtest/boardtest_sd.py
+++ b/adafruit_boardtest/boardtest_sd.py
@@ -37,6 +37,11 @@ import digitalio
 import adafruit_sdcard
 import storage
 
+try:
+    from typing import Sequence, Tuple, List
+except ImportError:
+    pass
+
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BoardTest.git"
 
@@ -58,13 +63,13 @@ NA = "N/A"
 
 
 def run_test(
-    pins,
-    mosi_pin=MOSI_PIN_NAME,
-    miso_pin=MISO_PIN_NAME,
-    sck_pin=SCK_PIN_NAME,
-    cs_pin=CS_PIN_NAME,
+    pins: Sequence[str],
+    mosi_pin: str = MOSI_PIN_NAME,
+    miso_pin: str = MISO_PIN_NAME,
+    sck_pin: str = SCK_PIN_NAME,
+    cs_pin: str = CS_PIN_NAME,
     filename: str = FILENAME
-):
+) -> Tuple[str, List[str]]:
 
     """
     Performs random writes and reads to file on attached SD card.

--- a/adafruit_boardtest/boardtest_sd.py
+++ b/adafruit_boardtest/boardtest_sd.py
@@ -63,6 +63,7 @@ def run_test(
     miso_pin=MISO_PIN_NAME,
     sck_pin=SCK_PIN_NAME,
     cs_pin=CS_PIN_NAME,
+    filename: str = FILENAME
 ):
 
     """
@@ -83,7 +84,7 @@ def run_test(
         # Tell user to connect SD card
         print("Insert SD card into holder and connect SPI lines to holder.")
         print("Connect " + cs_pin + " to the CS (DAT3) pin on the SD " + "card holder.")
-        print("WARNING: " + FILENAME + " will be created or overwritten.")
+        print("WARNING: " + filename + " will be created or overwritten.")
         print("Press enter to continue.")
         input()
 
@@ -115,7 +116,7 @@ def run_test(
 
         # Write test string to a text file on the card
         try:
-            with open("/sd/" + FILENAME, "w") as file:
+            with open("/sd/" + filename, "w") as file:
                 print("Writing:\t" + test_str)
                 file.write(test_str)
         except OSError:
@@ -125,7 +126,7 @@ def run_test(
         # Read from test file on the card
         read_str = ""
         try:
-            with open("/sd/" + FILENAME, "r") as file:
+            with open("/sd/" + filename, "r") as file:
                 lines = file.readlines()
                 for line in lines:
                     read_str += line

--- a/adafruit_boardtest/boardtest_sd_cd.py
+++ b/adafruit_boardtest/boardtest_sd_cd.py
@@ -29,6 +29,11 @@ Implementation Notes
 import board
 import digitalio
 
+try:
+    from typing import Sequence, Tuple, List
+except ImportError:
+    pass
+
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BoardTest.git"
 
@@ -41,7 +46,7 @@ FAIL = "FAIL"
 NA = "N/A"
 
 
-def run_test(pins, cd_pin=SD_CD_PIN_NAME):
+def run_test(pins: Sequence[str], cd_pin: str = SD_CD_PIN_NAME) -> Tuple[str, List[str]]:
 
     """
     Checks status of CD pin as user inserts and removes SD card.

--- a/adafruit_boardtest/boardtest_sd_cd.py
+++ b/adafruit_boardtest/boardtest_sd_cd.py
@@ -46,7 +46,9 @@ FAIL = "FAIL"
 NA = "N/A"
 
 
-def run_test(pins: Sequence[str], cd_pin: str = SD_CD_PIN_NAME) -> Tuple[str, List[str]]:
+def run_test(
+    pins: Sequence[str], cd_pin: str = SD_CD_PIN_NAME
+) -> Tuple[str, List[str]]:
 
     """
     Checks status of CD pin as user inserts and removes SD card.

--- a/adafruit_boardtest/boardtest_spi.py
+++ b/adafruit_boardtest/boardtest_spi.py
@@ -69,7 +69,9 @@ FAIL = "FAIL"
 NA = "N/A"
 
 # Wait for WIP bit to go low
-def _eeprom_spi_wait(spi: busio.SPI, csel: digitalio.DigitalInOut, timeout: float = 1.0) -> bool:
+def _eeprom_spi_wait(
+    spi: busio.SPI, csel: digitalio.DigitalInOut, timeout: float = 1.0
+) -> bool:
 
     # Continually read from STATUS register
     timestamp = time.monotonic()
@@ -90,7 +92,13 @@ def _eeprom_spi_wait(spi: busio.SPI, csel: digitalio.DigitalInOut, timeout: floa
 
 
 # Write to address. Returns status (True for successful write, False otherwise)
-def _eeprom_spi_write_byte(spi: busio.SPI, csel: digitalio.DigitalInOut, address: int, data: int, timeout: float = 1.0) -> bool:
+def _eeprom_spi_write_byte(
+    spi: busio.SPI,
+    csel: digitalio.DigitalInOut,
+    address: int,
+    data: int,
+    timeout: float = 1.0,
+) -> bool:
 
     # Make sure address is only one byte:
     if address > 255:
@@ -118,7 +126,9 @@ def _eeprom_spi_write_byte(spi: busio.SPI, csel: digitalio.DigitalInOut, address
 
 
 # Read from address. Returns tuple [status, result]
-def _eeprom_spi_read_byte(spi: busio.SPI, csel: digitalio.DigitalInOut, address: int, timeout: float = 1.0) -> Tuple[bool, bytearray]:
+def _eeprom_spi_read_byte(
+    spi: busio.SPI, csel: digitalio.DigitalInOut, address: int, timeout: float = 1.0
+) -> Tuple[bool, bytearray]:
 
     # Make sure address is only one byte:
     if address > 255:

--- a/adafruit_boardtest/boardtest_spi.py
+++ b/adafruit_boardtest/boardtest_spi.py
@@ -36,6 +36,11 @@ import board
 import digitalio
 import busio
 
+try:
+    from typing import Tuple, Sequence, List
+except ImportError:
+    pass
+
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BoardTest.git"
 
@@ -64,7 +69,7 @@ FAIL = "FAIL"
 NA = "N/A"
 
 # Wait for WIP bit to go low
-def _eeprom_spi_wait(spi, csel, timeout=1.0):
+def _eeprom_spi_wait(spi: busio.SPI, csel: digitalio.DigitalInOut, timeout: float = 1.0) -> bool:
 
     # Continually read from STATUS register
     timestamp = time.monotonic()
@@ -85,7 +90,7 @@ def _eeprom_spi_wait(spi, csel, timeout=1.0):
 
 
 # Write to address. Returns status (True for successful write, False otherwise)
-def _eeprom_spi_write_byte(spi, csel, address, data, timeout=1.0):
+def _eeprom_spi_write_byte(spi: busio.SPI, csel: digitalio.DigitalInOut, address: int, data: int, timeout: float = 1.0) -> bool:
 
     # Make sure address is only one byte:
     if address > 255:
@@ -113,7 +118,7 @@ def _eeprom_spi_write_byte(spi, csel, address, data, timeout=1.0):
 
 
 # Read from address. Returns tuple [status, result]
-def _eeprom_spi_read_byte(spi, csel, address, timeout=1.0):
+def _eeprom_spi_read_byte(spi: busio.SPI, csel: digitalio.DigitalInOut, address: int, timeout: float = 1.0) -> Tuple[bool, bytearray]:
 
     # Make sure address is only one byte:
     if address > 255:
@@ -134,12 +139,12 @@ def _eeprom_spi_read_byte(spi, csel, address, timeout=1.0):
 
 
 def run_test(
-    pins,
-    mosi_pin=MOSI_PIN_NAME,
-    miso_pin=MISO_PIN_NAME,
-    sck_pin=SCK_PIN_NAME,
-    cs_pin=CS_PIN_NAME,
-):
+    pins: Sequence[str],
+    mosi_pin: str = MOSI_PIN_NAME,
+    miso_pin: str = MISO_PIN_NAME,
+    sck_pin: str = SCK_PIN_NAME,
+    cs_pin: str = CS_PIN_NAME,
+) -> Tuple[str, List[str]]:
 
     """
     Performs random writes and reads to file on attached SD card.

--- a/adafruit_boardtest/boardtest_uart.py
+++ b/adafruit_boardtest/boardtest_uart.py
@@ -54,6 +54,7 @@ def run_test(pins, tx_pin=TX_PIN_NAME, rx_pin=RX_PIN_NAME, baud_rate=BAUD_RATE):
     :param list[str] pins: list of pins to run the test on
     :param str tx_pin: pin name of UART TX
     :param str rx_pin: pin name of UART RX
+    :param int baudrate: the baudrate to use
     :return: tuple(str, list[str]): test result followed by list of pins tested
     """
 

--- a/adafruit_boardtest/boardtest_uart.py
+++ b/adafruit_boardtest/boardtest_uart.py
@@ -51,7 +51,12 @@ FAIL = "FAIL"
 NA = "N/A"
 
 
-def run_test(pins: Sequence[str], tx_pin: str = TX_PIN_NAME, rx_pin: str = RX_PIN_NAME, baud_rate: int = BAUD_RATE) -> Tuple[str, List[str]]:
+def run_test(
+    pins: Sequence[str],
+    tx_pin: str = TX_PIN_NAME,
+    rx_pin: str = RX_PIN_NAME,
+    baud_rate: int = BAUD_RATE,
+) -> Tuple[str, List[str]]:
 
     """
     Performs random writes out of TX pin and reads on RX.

--- a/adafruit_boardtest/boardtest_uart.py
+++ b/adafruit_boardtest/boardtest_uart.py
@@ -29,6 +29,11 @@ import random
 import board
 import busio
 
+try:
+    from typing import Sequence, Tuple, List
+except ImportError:
+    pass
+
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BoardTest.git"
 
@@ -46,7 +51,7 @@ FAIL = "FAIL"
 NA = "N/A"
 
 
-def run_test(pins, tx_pin=TX_PIN_NAME, rx_pin=RX_PIN_NAME, baud_rate=BAUD_RATE):
+def run_test(pins: Sequence[str], tx_pin: str = TX_PIN_NAME, rx_pin: str = RX_PIN_NAME, baud_rate: int = BAUD_RATE) -> Tuple[str, List[str]]:
 
     """
     Performs random writes out of TX pin and reads on RX.

--- a/adafruit_boardtest/boardtest_voltage_monitor.py
+++ b/adafruit_boardtest/boardtest_voltage_monitor.py
@@ -31,6 +31,11 @@ Implementation Notes
 import board
 import analogio
 
+try:
+    from typing import Sequence, Tuple, List
+except ImportError:
+    pass
+
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BoardTest.git"
 
@@ -45,7 +50,7 @@ FAIL = "FAIL"
 NA = "N/A"
 
 
-def run_test(pins):
+def run_test(pins: Sequence[str]) -> Tuple[str, List[str]]:
 
     """
     Prints out voltage on the battery monitor or voltage monitor pin.


### PR DESCRIPTION
1. Added type hints
2. `adafruit_boardtest\boardtest_sd.py` was not using a filename as a parameter in `run_test()` as the docstring implied.  It looked like that was the intention so I now have it take a `filename` parameter that defaults to `FILENAME`
3. `baudrate` was not documented in the method docstring for `run_test()` in `adafruit_boardtest\boardtest_uart.py` so I added the Sphinx param to it.
4. Also had to locally disable a couple pylint warnings in `adafruit_boardtest\boardtest_sd.py` because it seems like `run_test()` is written as intended and readable, so the warnings should just be surpressed (too many arguments, too many local variables)